### PR TITLE
UPDATED the default maven surefire plugin as plexus-utils included in…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 	      <artifactId>maven-surefire-plugin</artifactId>
 	      <version>2.19</version>
 	      <configuration>
-	         <skipTests>true</skipTests>
+	         <skipTests>false</skipTests>
 	      </configuration>
             </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,15 @@
                     </archive>
                 </configuration>
             </plugin>
-        </plugins>
+ 
+            <plugin>
+	      <groupId>org.apache.maven.plugins</groupId>
+	      <artifactId>maven-surefire-plugin</artifactId>
+	      <version>2.19</version>
+	      <configuration>
+	         <skipTests>true</skipTests>
+	      </configuration>
+            </plugin>
+    </plugins>
     </build>
 </project>


### PR DESCRIPTION
UPDATED the default maven surefire plugin as plexus-utils included in 2.9, which is a dependency of maven-surefire-plugin 2.12.4 has the vulnerability

https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin/2.12.4